### PR TITLE
Update color_utils.dart

### DIFF
--- a/lib/src/core/color_utils.dart
+++ b/lib/src/core/color_utils.dart
@@ -13,4 +13,10 @@ class ColorUtils {
     final yiq = (299 * color.red + 587 * color.green + 114 * color.blue) / 1000;
     return yiq >= 128 ? Colors.black : Colors.white;
   }
+
+  static Color contrastThemeColor(Color color) {
+    final Brightness brightness = ThemeData.estimateBrightnessForColor(color);
+    return brightness == Brightness.dark ? Colors.white : Colors.black;
+  }
 }
+

--- a/lib/src/debug/theme/color_page.dart
+++ b/lib/src/debug/theme/color_page.dart
@@ -1,6 +1,10 @@
 import 'package:flutter/material.dart';
 
-import 'sample_object.dart';
+import 'sample_color_alpha.dart';
+import 'sample_color_red.dart';
+import 'sample_color_green.dart';
+import 'sample_color_blue.dart';
+import 'sample_color_value.dart';
 
 class ColorPage extends StatelessWidget {
   final Color color;
@@ -20,45 +24,33 @@ class ColorPage extends StatelessWidget {
         children: <Widget>[
           Padding(
             padding: EdgeInsets.all(8),
-            child: SampleObject(
-              title: 'alpha',
-              object: color.alpha,
-            ), // SampleObject
+            child: SampleColorAlpha(
+              alpha: color.alpha,
+            ), // SampleColorAlpha
           ), // Padding
           Padding(
             padding: EdgeInsets.all(8),
-            child: SampleObject(
-              title: 'blue',
-              object: color.blue,
-            ), // SampleObject
+            child: SampleColorRed(
+              red: color.red,
+            ), // SampleColorRed
           ), // Padding
           Padding(
             padding: EdgeInsets.all(8),
-            child: SampleObject(
-              title: 'green',
-              object: color.green,
-            ), // SampleObject
+            child: SampleColorGreen(
+              green: color.green,
+            ), // SampleColorGreen
           ), // Padding
           Padding(
             padding: EdgeInsets.all(8),
-            child: SampleObject(
-              title: 'opacity',
-              object: color.opacity,
-            ), // SampleObject
+            child: SampleColorBlue(
+              blue: color.blue,
+            ), // SampleColorBlue
           ), // Padding
           Padding(
-            padding: EdgeInsets.all(8),
-            child: SampleObject(
-              title: 'red',
-              object: color.red,
-            ), // SampleObject
-          ), // Padding
-          Padding(
-            padding: EdgeInsets.all(8),
-            child: SampleObject(
-              title: 'value',
-              object: color.value,
-            ), // SampleObject
+            padding: EdgeInsets.fromLTRB(8, 12, 8, 8),
+            child: SampleColorValue(
+              value: color,
+            ), // SampleColorValue
           ), // Padding
         ],
       ), // ListView

--- a/lib/src/debug/theme/sample_color_alpha.dart
+++ b/lib/src/debug/theme/sample_color_alpha.dart
@@ -1,0 +1,64 @@
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+
+class SampleColorAlpha extends StatelessWidget {
+  final int alpha;
+
+  const SampleColorAlpha({
+    super.key,
+    required this.alpha,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    //final textTheme = Theme.of(context).textTheme;
+    final colorScheme = Theme.of(context).colorScheme;
+
+    final child = Container(
+      width: double.infinity,
+      height: Get.width / 2 / 1.618,
+      decoration: BoxDecoration(
+        borderRadius: BorderRadius.circular(20),
+        color: colorScheme.primaryContainer,
+      ), // BoxDecoration
+      padding: EdgeInsets.all(8.0),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        children: [
+          AspectRatio(
+            aspectRatio: 1.0,
+            child: Container(
+              alignment: Alignment.center,
+              child: Text('A',
+                  style: Theme.of(context)
+                      .textTheme
+                      .displayLarge!
+                      .copyWith(color: colorScheme.onPrimary)),
+              decoration: BoxDecoration(
+                borderRadius: BorderRadius.circular(12),
+                color: colorScheme.primary,
+              ), // BoxDecoration
+            ), // Container
+          ), // AspectRatio
+          Container(
+            alignment: Alignment.center,
+            child: Text(
+                '#${alpha.toRadixString(16).padLeft(2, '0').toUpperCase()}',
+                style: Theme.of(context)
+                    .textTheme
+                    .headlineLarge!
+                    .copyWith(color: colorScheme.onPrimaryContainer)),
+            color: Colors.transparent,
+          ), // Container
+        ],
+      ), // Row
+    ); // Container
+
+    return Material(
+      elevation: 4,
+      borderRadius: BorderRadius.circular(20),
+      child: child,
+    ); // Material
+  }
+}

--- a/lib/src/debug/theme/sample_color_blue.dart
+++ b/lib/src/debug/theme/sample_color_blue.dart
@@ -1,0 +1,77 @@
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+
+import '../../core/color_utils.dart';
+
+class SampleColorBlue extends StatelessWidget {
+  final int blue;
+
+  const SampleColorBlue({
+    Key? key,
+    required this.blue,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    //final textTheme = Theme.of(context).textTheme;
+    final colorScheme = Theme.of(context).colorScheme;
+
+    final containerHeight = Get.width / 2 / 1.618;
+    final containerColor = Color.fromARGB(255, 0, 0, blue);
+
+    return Material(
+      elevation: 4,
+      borderRadius: BorderRadius.circular(20),
+      child: Container(
+        width: double.infinity,
+        height: containerHeight,
+        decoration: BoxDecoration(
+          borderRadius: BorderRadius.circular(20),
+          color: containerColor,
+        ),
+        padding: const EdgeInsets.all(8.0),
+        child: Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: [
+            _buildBlueTextBox(context, colorScheme),
+            _buildAlphaTextBox(context, containerColor),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildBlueTextBox(BuildContext context, ColorScheme colorScheme) {
+    return AspectRatio(
+      aspectRatio: 1.0,
+      child: Container(
+        alignment: Alignment.center,
+        decoration: BoxDecoration(
+          borderRadius: BorderRadius.circular(12),
+          color: Colors.blue,
+        ),
+        child: Text(
+          'B',
+          style: Theme.of(context)
+              .textTheme
+              .displayLarge!
+              .copyWith(color: ColorUtils.contrastThemeColor(Colors.blue)),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildAlphaTextBox(BuildContext context, Color containerColor) {
+    return Container(
+      alignment: Alignment.center,
+      color: Colors.transparent,
+      child: Text(
+        '#${blue.toRadixString(16).padLeft(2, '0').toUpperCase()}',
+        style: Theme.of(context)
+            .textTheme
+            .headlineLarge!
+            .copyWith(color: ColorUtils.contrastThemeColor(containerColor)),
+      ),
+    );
+  }
+}

--- a/lib/src/debug/theme/sample_color_green.dart
+++ b/lib/src/debug/theme/sample_color_green.dart
@@ -1,0 +1,77 @@
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+
+import '../../core/color_utils.dart';
+
+class SampleColorGreen extends StatelessWidget {
+  final int green;
+
+  const SampleColorGreen({
+    Key? key,
+    required this.green,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    //final textTheme = Theme.of(context).textTheme;
+    final colorScheme = Theme.of(context).colorScheme;
+
+    final containerHeight = Get.width / 2 / 1.618;
+    final containerColor = Color.fromARGB(255, 0, green, 0);
+
+    return Material(
+      elevation: 4,
+      borderRadius: BorderRadius.circular(20),
+      child: Container(
+        width: double.infinity,
+        height: containerHeight,
+        decoration: BoxDecoration(
+          borderRadius: BorderRadius.circular(20),
+          color: containerColor,
+        ),
+        padding: const EdgeInsets.all(8.0),
+        child: Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: [
+            _buildGreenTextBox(context, colorScheme),
+            _buildAlphaTextBox(context, containerColor),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildGreenTextBox(BuildContext context, ColorScheme colorScheme) {
+    return AspectRatio(
+      aspectRatio: 1.0,
+      child: Container(
+        alignment: Alignment.center,
+        decoration: BoxDecoration(
+          borderRadius: BorderRadius.circular(12),
+          color: Colors.green,
+        ),
+        child: Text(
+          'G',
+          style: Theme.of(context)
+              .textTheme
+              .displayLarge!
+              .copyWith(color: ColorUtils.contrastThemeColor(Colors.green)),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildAlphaTextBox(BuildContext context, Color containerColor) {
+    return Container(
+      alignment: Alignment.center,
+      color: Colors.transparent,
+      child: Text(
+        '#${green.toRadixString(16).padLeft(2, '0').toUpperCase()}',
+        style: Theme.of(context)
+            .textTheme
+            .headlineLarge!
+            .copyWith(color: ColorUtils.contrastThemeColor(containerColor)),
+      ),
+    );
+  }
+}

--- a/lib/src/debug/theme/sample_color_red.dart
+++ b/lib/src/debug/theme/sample_color_red.dart
@@ -1,0 +1,77 @@
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+
+import '../../core/color_utils.dart';
+
+class SampleColorRed extends StatelessWidget {
+  final int red;
+
+  const SampleColorRed({
+    Key? key,
+    required this.red,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    //final textTheme = Theme.of(context).textTheme;
+    final colorScheme = Theme.of(context).colorScheme;
+
+    final containerHeight = Get.width / 2 / 1.618;
+    final containerColor = Color.fromARGB(255, red, 0, 0);
+
+    return Material(
+      elevation: 4,
+      borderRadius: BorderRadius.circular(20),
+      child: Container(
+        width: double.infinity,
+        height: containerHeight,
+        decoration: BoxDecoration(
+          borderRadius: BorderRadius.circular(20),
+          color: containerColor,
+        ),
+        padding: const EdgeInsets.all(8.0),
+        child: Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: [
+            _buildRedTextBox(context, colorScheme),
+            _buildAlphaTextBox(context, containerColor),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildRedTextBox(BuildContext context, ColorScheme colorScheme) {
+    return AspectRatio(
+      aspectRatio: 1.0,
+      child: Container(
+        alignment: Alignment.center,
+        decoration: BoxDecoration(
+          borderRadius: BorderRadius.circular(12),
+          color: Colors.red,
+        ),
+        child: Text(
+          'R',
+          style: Theme.of(context)
+              .textTheme
+              .displayLarge!
+              .copyWith(color: ColorUtils.contrastThemeColor(Colors.red)),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildAlphaTextBox(BuildContext context, Color containerColor) {
+    return Container(
+      alignment: Alignment.center,
+      color: Colors.transparent,
+      child: Text(
+        '#${red.toRadixString(16).padLeft(2, '0').toUpperCase()}',
+        style: Theme.of(context)
+            .textTheme
+            .headlineLarge!
+            .copyWith(color: ColorUtils.contrastThemeColor(containerColor)),
+      ),
+    );
+  }
+}

--- a/lib/src/debug/theme/sample_color_value.dart
+++ b/lib/src/debug/theme/sample_color_value.dart
@@ -1,0 +1,78 @@
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+
+import '../../core/color_utils.dart';
+
+class SampleColorValue extends StatelessWidget {
+  final Color value;
+
+  const SampleColorValue({
+    Key? key,
+    required this.value,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    //final textTheme = Theme.of(context).textTheme;
+    final colorScheme = Theme.of(context).colorScheme;
+
+    final containerHeight = Get.width / 2 / 1.618;
+    final containerColor =
+        Color.fromARGB(255, value.red, value.green, value.blue);
+
+    return Material(
+      elevation: 4,
+      borderRadius: BorderRadius.circular(20),
+      child: Container(
+        width: double.infinity,
+        height: containerHeight,
+        decoration: BoxDecoration(
+          borderRadius: BorderRadius.circular(20),
+          color: containerColor,
+        ),
+        padding: const EdgeInsets.all(8.0),
+        child: Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: [
+            _buildRedTextBox(context, colorScheme),
+            _buildAlphaTextBox(context, containerColor),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildRedTextBox(BuildContext context, ColorScheme colorScheme) {
+    return AspectRatio(
+      aspectRatio: 1.0,
+      child: Container(
+        alignment: Alignment.center,
+        decoration: BoxDecoration(
+          borderRadius: BorderRadius.circular(12),
+          color: colorScheme.primary,
+        ),
+        child: Text(
+          'C',
+          style: Theme.of(context)
+              .textTheme
+              .displayLarge!
+              .copyWith(color: colorScheme.onPrimary),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildAlphaTextBox(BuildContext context, Color containerColor) {
+    return Container(
+      alignment: Alignment.center,
+      color: Colors.transparent,
+      child: Text(
+        '#${value.value.toRadixString(16).padLeft(8, '0').toUpperCase()}',
+        style: Theme.of(context)
+            .textTheme
+            .headlineLarge!
+            .copyWith(color: ColorUtils.contrastThemeColor(containerColor)),
+      ),
+    );
+  }
+}

--- a/lib/src/home/entities/original_image.dart
+++ b/lib/src/home/entities/original_image.dart
@@ -1,6 +1,6 @@
 class OriginalImage {
   static final String wikiLogo =
-      'https://upload.wikimedia.org/wikipedia/en/thumb/8/80/Wikipedia-logo-v2.svg/220px-Wikipedia-logo-v2.svg.png';
+      'https://upload.wikimedia.org/wikipedia/en/thumb/8/80/Wikipedia-logo-v2.svg/640px-Wikipedia-logo-v2.svg.png';
 
   final String source;
   final int width;

--- a/lib/src/home/home_controller.dart
+++ b/lib/src/home/home_controller.dart
@@ -107,7 +107,7 @@ class HomeController extends GetxController {
       }
       if (zeroes[0].wiki != null &&  zeroes[0].wiki!.title != null) {
         final sum = await readSummary(zeroes[0].wiki!.title!);
-        zeroes[0].wiki!.description = sum.description;
+        zeroes[0].wiki!.description = sum.extract;
       }
       animeList.sort(
           (a, b) => (b.wiki?.mviMonth ?? 0).compareTo(a.wiki?.mviMonth ?? 0));


### PR DESCRIPTION
## Summary by Sourcery

Introduce specialized color-sample widgets for each ARGB channel, integrate a contrast color utility, and apply minor data and mapping fixes

New Features:
- Add SampleColorAlpha, SampleColorRed, SampleColorGreen, SampleColorBlue, and SampleColorValue widgets for channel-specific color previews

Bug Fixes:
- Correct HomeController to assign wiki description from extract instead of description

Enhancements:
- Replace generic SampleObject with dedicated sample color widgets in ColorPage
- Add contrastThemeColor utility in ColorUtils to compute contrasting text color
- Update OriginalImage to use a higher-resolution Wikipedia logo URL