### PR TITLE
Update sample_color_alpha.dart

### DIFF
--- a/lib/src/debug/theme/sample_color_alpha.dart
+++ b/lib/src/debug/theme/sample_color_alpha.dart
@@ -11,54 +11,53 @@ class SampleColorAlpha extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    //final textTheme = Theme.of(context).textTheme;
     final colorScheme = Theme.of(context).colorScheme;
-
-    final child = Container(
-      width: double.infinity,
-      height: Get.width / 2 / 1.618,
-      decoration: BoxDecoration(
-        borderRadius: BorderRadius.circular(20),
-        color: colorScheme.primaryContainer,
-      ), // BoxDecoration
-      padding: EdgeInsets.all(8.0),
-      child: Row(
-        mainAxisSize: MainAxisSize.min,
-        mainAxisAlignment: MainAxisAlignment.spaceBetween,
-        children: [
-          AspectRatio(
-            aspectRatio: 1.0,
-            child: Container(
-              alignment: Alignment.center,
-              child: Text('A',
-                  style: Theme.of(context)
-                      .textTheme
-                      .displayLarge!
-                      .copyWith(color: colorScheme.onPrimary)),
-              decoration: BoxDecoration(
-                borderRadius: BorderRadius.circular(12),
-                color: colorScheme.primary,
-              ), // BoxDecoration
-            ), // Container
-          ), // AspectRatio
-          Container(
-            alignment: Alignment.center,
-            child: Text(
-                '#${alpha.toRadixString(16).padLeft(2, '0').toUpperCase()}',
-                style: Theme.of(context)
-                    .textTheme
-                    .headlineLarge!
-                    .copyWith(color: colorScheme.onPrimaryContainer)),
-            color: Colors.transparent,
-          ), // Container
-        ],
-      ), // Row
-    ); // Container
 
     return Material(
       elevation: 4,
       borderRadius: BorderRadius.circular(20),
-      child: child,
-    ); // Material
+      child: Container(
+        width: double.infinity,
+        height: Get.width / 2 / 1.618,
+        decoration: BoxDecoration(
+          borderRadius: BorderRadius.circular(20),
+          color: colorScheme.primaryContainer,
+        ),
+        padding: EdgeInsets.all(16.0), // Увеличенные отступы
+        child: Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: [
+            AspectRatio(
+              aspectRatio: 1.0,
+              child: Container(
+                alignment: Alignment.center,
+                decoration: BoxDecoration(
+                  borderRadius: BorderRadius.circular(12),
+                  color: colorScheme.primary,
+                ),
+                child: Text(
+                  'A',
+                  style: Theme.of(context)
+                      .textTheme
+                      .displayLarge!
+                      .copyWith(color: colorScheme.onPrimary),
+                ),
+              ),
+            ),
+            SizedBox(width: 16), // Отступ между элементами
+            Container(
+              alignment: Alignment.center,
+              child: Text(
+                '#${alpha.toRadixString(16).padLeft(2, '0').toUpperCase()}',
+                style: Theme.of(context)
+                    .textTheme
+                    .headlineLarge!
+                    .copyWith(color: colorScheme.onPrimaryContainer),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
   }
 }


### PR DESCRIPTION
## Summary by Sourcery

Refactor SampleColorAlpha widget to enhance layout and styling

Enhancements:
- Increase padding inside the color container from 8 to 16
- Add horizontal spacing between the color preview and alpha text
- Return Material-wrapped container directly and remove unused intermediate child variable
- Consolidate decorations and remove redundant transparent background and commented code