### PR TITLE
Update home_view.dart

### DIFF
--- a/lib/src/home/home_view.dart
+++ b/lib/src/home/home_view.dart
@@ -84,7 +84,7 @@ class HomeView extends StatelessWidget {
                   SizedBox(height: 8),
                   Text(
                     "${item.wiki?.description ?? ''}",
-                    maxLines: 2,
+                    maxLines: 5,
                     overflow: TextOverflow.ellipsis, // Обрезка текста
                     style: textTheme.bodyMedium,
                   ),


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Allow up to 5 lines for the wiki description text in the home view instead of 2