### PR TITLE
ColorPage minor updates

### DIFF
--- a/lib/src/debug/theme/chessboard.dart
+++ b/lib/src/debug/theme/chessboard.dart
@@ -3,17 +3,20 @@ import 'package:flutter/material.dart';
 class ChessboardBackground extends StatelessWidget {
   final double squareSize;
 
-  const ChessboardBackground({super.key, required this.squareSize});
+  const ChessboardBackground({Key? key, required this.squareSize}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
-    return Container(
-      decoration: BoxDecoration(
-        color: Colors.transparent,
-      ),
-      child: CustomPaint(
-        size: Size.square(squareSize),
-        painter: ChessboardPainter(),
+    return ClipRRect(
+      borderRadius: BorderRadius.circular(20),
+      child: Container(
+        decoration: const BoxDecoration(
+          color: Colors.transparent,
+        ),
+        child: CustomPaint(
+          size: Size.square(squareSize),
+          painter: ChessboardPainter(),
+        ),
       ),
     );
   }

--- a/lib/src/debug/theme/chessboard.dart
+++ b/lib/src/debug/theme/chessboard.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 
 class ChessboardBackground extends StatelessWidget {
-  final double size;
+  final Size size;
 
   const ChessboardBackground({
     super.key,

--- a/lib/src/debug/theme/chessboard.dart
+++ b/lib/src/debug/theme/chessboard.dart
@@ -1,9 +1,12 @@
 import 'package:flutter/material.dart';
 
 class ChessboardBackground extends StatelessWidget {
-  final double squareSize;
+  final double size;
 
-  const ChessboardBackground({Key? key, required this.squareSize}) : super(key: key);
+  const ChessboardBackground({
+    super.key,
+    required this.size,
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -14,7 +17,7 @@ class ChessboardBackground extends StatelessWidget {
           color: Colors.transparent,
         ),
         child: CustomPaint(
-          size: Size.square(squareSize),
+          size: this.size,
           painter: ChessboardPainter(),
         ),
       ),

--- a/lib/src/debug/theme/color_page.dart
+++ b/lib/src/debug/theme/color_page.dart
@@ -30,7 +30,7 @@ class ColorPage extends StatelessWidget {
           builder: (context, value, child) {
             return SampleColorAlpha(
               alpha: value.alpha,
-            ), // SampleColorAlpha
+            ); // SampleColorAlpha
           },
         ), // ValueListenableBuilder<Color>
           ), // Padding
@@ -42,7 +42,7 @@ class ColorPage extends StatelessWidget {
           builder: (context, value, child) {
             return SampleColorRed(
               red: value.red,
-            ), // SampleColorRed
+            ); // SampleColorRed
           },
         ), // ValueListenableBuilder<Color>
           ), // Padding
@@ -54,7 +54,7 @@ class ColorPage extends StatelessWidget {
           builder: (context, value, child) {
             return SampleColorGreen(
               green: value.green,
-            ), // SampleColorGreen
+            ); // SampleColorGreen
           },
         ), // ValueListenableBuilder<Color>
           ), // Padding
@@ -66,7 +66,7 @@ class ColorPage extends StatelessWidget {
           builder: (context, value, child) {
             return SampleColorBlue(
               blue: value.blue,
-            ), // SampleColorBlue
+            ); // SampleColorBlue
           },
         ), // ValueListenableBuilder<Color>
           ), // Padding
@@ -78,7 +78,7 @@ class ColorPage extends StatelessWidget {
           builder: (context, value, child) {
             return SampleColorValue(
               value: value,
-            ), // SampleColorValue
+            ); // SampleColorValue
           },
         ), // ValueListenableBuilder<Color>
           ), // Padding

--- a/lib/src/debug/theme/color_page.dart
+++ b/lib/src/debug/theme/color_page.dart
@@ -7,6 +7,7 @@ import 'sample_color_blue.dart';
 import 'sample_color_value.dart';
 
 class ColorPage extends StatelessWidget {
+  final ValueNotifier<Color>;
   final Color color;
 
   const ColorPage({

--- a/lib/src/debug/theme/color_page.dart
+++ b/lib/src/debug/theme/color_page.dart
@@ -10,7 +10,7 @@ class ColorPage extends StatelessWidget {
   final ValueNotifier<Color> colorNotifier;
   final Color color;
 
-  const ColorPage({
+  ColorPage({
     super.key,
     required this.color,
   }) : colorNotifier = ValueNotifier<Color>(color);
@@ -30,8 +30,8 @@ class ColorPage extends StatelessWidget {
               builder: (context, value, child) {
                 return SampleColorAlpha(
                   alpha: value.alpha,
-                  onChanged: (value) {
-                    colorNotifier.value = colorNotifier.value.withAlpha(value);
+                  onChanged: (newValue) {
+                    colorNotifier.value = colorNotifier.value.withAlpha(newValue);
                   },
                 ); // SampleColorAlpha
               },

--- a/lib/src/debug/theme/color_page.dart
+++ b/lib/src/debug/theme/color_page.dart
@@ -30,6 +30,9 @@ class ColorPage extends StatelessWidget {
               builder: (context, value, child) {
                 return SampleColorAlpha(
                   alpha: value.alpha,
+                  onChanged: (value) {
+                    colorNotifier.value = colorNotifier.value.withAlpha(value);
+                  },
                 ); // SampleColorAlpha
               },
             ), // ValueListenableBuilder<Color>

--- a/lib/src/debug/theme/color_page.dart
+++ b/lib/src/debug/theme/color_page.dart
@@ -25,62 +25,62 @@ class ColorPage extends StatelessWidget {
         children: <Widget>[
           Padding(
             padding: EdgeInsets.all(8),
-            child:         ValueListenableBuilder<Color>(
-          valueListenable: colorNotifier,
-          builder: (context, value, child) {
-            return SampleColorAlpha(
-              alpha: value.alpha,
-            ); // SampleColorAlpha
-          },
-        ), // ValueListenableBuilder<Color>
+            child: ValueListenableBuilder<Color>(
+              valueListenable: colorNotifier,
+              builder: (context, value, child) {
+                return SampleColorAlpha(
+                  alpha: value.alpha,
+                ); // SampleColorAlpha
+              },
+            ), // ValueListenableBuilder<Color>
           ), // Padding
 
           Padding(
             padding: EdgeInsets.all(8),
-            child:         ValueListenableBuilder<Color>(
-          valueListenable: colorNotifier,
-          builder: (context, value, child) {
-            return SampleColorRed(
-              red: value.red,
-            ); // SampleColorRed
-          },
-        ), // ValueListenableBuilder<Color>
+            child: ValueListenableBuilder<Color>(
+              valueListenable: colorNotifier,
+              builder: (context, value, child) {
+                return SampleColorRed(
+                  red: value.red,
+                ); // SampleColorRed
+              },
+            ), // ValueListenableBuilder<Color>
           ), // Padding
 
           Padding(
             padding: EdgeInsets.all(8),
-            child:         ValueListenableBuilder<Color>(
-          valueListenable: colorNotifier,
-          builder: (context, value, child) {
-            return SampleColorGreen(
-              green: value.green,
-            ); // SampleColorGreen
-          },
-        ), // ValueListenableBuilder<Color>
+            child: ValueListenableBuilder<Color>(
+              valueListenable: colorNotifier,
+              builder: (context, value, child) {
+                return SampleColorGreen(
+                  green: value.green,
+                ); // SampleColorGreen
+              },
+            ), // ValueListenableBuilder<Color>
           ), // Padding
 
           Padding(
             padding: EdgeInsets.all(8),
-            child:         ValueListenableBuilder<Color>(
-          valueListenable: colorNotifier,
-          builder: (context, value, child) {
-            return SampleColorBlue(
-              blue: value.blue,
-            ); // SampleColorBlue
-          },
-        ), // ValueListenableBuilder<Color>
+            child: ValueListenableBuilder<Color>(
+              valueListenable: colorNotifier,
+              builder: (context, value, child) {
+                return SampleColorBlue(
+                  blue: value.blue,
+                ); // SampleColorBlue
+              },
+            ), // ValueListenableBuilder<Color>
           ), // Padding
 
           Padding(
             padding: EdgeInsets.fromLTRB(8, 12, 8, 8),
-            child:         ValueListenableBuilder<Color>(
-          valueListenable: colorNotifier,
-          builder: (context, value, child) {
-            return SampleColorValue(
-              value: value,
-            ); // SampleColorValue
-          },
-        ), // ValueListenableBuilder<Color>
+            child: ValueListenableBuilder<Color>(
+              valueListenable: colorNotifier,
+              builder: (context, value, child) {
+                return SampleColorValue(
+                  value: value,
+                ); // SampleColorValue
+              },
+            ), // ValueListenableBuilder<Color>
           ), // Padding
         ],
       ), // ListView

--- a/lib/src/debug/theme/color_page.dart
+++ b/lib/src/debug/theme/color_page.dart
@@ -7,13 +7,13 @@ import 'sample_color_blue.dart';
 import 'sample_color_value.dart';
 
 class ColorPage extends StatelessWidget {
-  final ValueNotifier<Color>;
+  final ValueNotifier<Color> colorNotifier;
   final Color color;
 
   const ColorPage({
     super.key,
     required this.color,
-  });
+  }) : colorNotifier = ValueNotifier<Color>(color);
 
   @override
   Widget build(context) {

--- a/lib/src/debug/theme/color_page.dart
+++ b/lib/src/debug/theme/color_page.dart
@@ -25,33 +25,62 @@ class ColorPage extends StatelessWidget {
         children: <Widget>[
           Padding(
             padding: EdgeInsets.all(8),
-            child: SampleColorAlpha(
-              alpha: color.alpha,
+            child:         ValueListenableBuilder<Color>(
+          valueListenable: colorNotifier,
+          builder: (context, value, child) {
+            return SampleColorAlpha(
+              alpha: value.alpha,
             ), // SampleColorAlpha
+          },
+        ), // ValueListenableBuilder<Color>
           ), // Padding
+
           Padding(
             padding: EdgeInsets.all(8),
-            child: SampleColorRed(
-              red: color.red,
+            child:         ValueListenableBuilder<Color>(
+          valueListenable: colorNotifier,
+          builder: (context, value, child) {
+            return SampleColorRed(
+              red: value.red,
             ), // SampleColorRed
+          },
+        ), // ValueListenableBuilder<Color>
           ), // Padding
+
           Padding(
             padding: EdgeInsets.all(8),
-            child: SampleColorGreen(
-              green: color.green,
+            child:         ValueListenableBuilder<Color>(
+          valueListenable: colorNotifier,
+          builder: (context, value, child) {
+            return SampleColorGreen(
+              green: value.green,
             ), // SampleColorGreen
+          },
+        ), // ValueListenableBuilder<Color>
           ), // Padding
+
           Padding(
             padding: EdgeInsets.all(8),
-            child: SampleColorBlue(
-              blue: color.blue,
+            child:         ValueListenableBuilder<Color>(
+          valueListenable: colorNotifier,
+          builder: (context, value, child) {
+            return SampleColorBlue(
+              blue: value.blue,
             ), // SampleColorBlue
+          },
+        ), // ValueListenableBuilder<Color>
           ), // Padding
+
           Padding(
             padding: EdgeInsets.fromLTRB(8, 12, 8, 8),
-            child: SampleColorValue(
-              value: color,
+            child:         ValueListenableBuilder<Color>(
+          valueListenable: colorNotifier,
+          builder: (context, value, child) {
+            return SampleColorValue(
+              value: value,
             ), // SampleColorValue
+          },
+        ), // ValueListenableBuilder<Color>
           ), // Padding
         ],
       ), // ListView

--- a/lib/src/debug/theme/sample_color_alpha.dart
+++ b/lib/src/debug/theme/sample_color_alpha.dart
@@ -6,7 +6,7 @@ import 'chessboard.dart';
 class SampleColorAlpha extends StatelessWidget {
   final int alpha;
 
-  final ValueChanged<Color>? onChanged;
+  final ValueChanged<int>? onChanged;
 
   const SampleColorAlpha({
     super.key,

--- a/lib/src/debug/theme/sample_color_alpha.dart
+++ b/lib/src/debug/theme/sample_color_alpha.dart
@@ -27,57 +27,56 @@ class SampleColorAlpha extends StatelessWidget {
               size: Size.new(Get.width - 2 * 8.0, Get.width / 2 / 1.618)),
           GestureDetector(
             onHorizontalDragEnd: (details) {
-                    if (details.primaryVelocity == null) return;
-                    if (details.primaryVelocity!.value < 0.0) {
-                      this.onChanged?.call((this.alpha + 256 - 1) % 256);
-                    } else if (details.primaryVelocity!.value > 0.0) {
-                      this.onChanged?.call((this.alpha + 1) % 256);
-                    }
-                  },
+              if (details.primaryVelocity == null) return;
+              if (details.primaryVelocity!.value < 0.0) {
+                this.onChanged?.call((this.alpha + 256 - 1) % 256);
+              } else if (details.primaryVelocity!.value > 0.0) {
+                this.onChanged?.call((this.alpha + 1) % 256);
+              }
+            },
             child: Container(
-            width: double.infinity,
-            height: Get.width / 2 / 1.618,
-            decoration: BoxDecoration(
-              borderRadius: BorderRadius.circular(20),
-              color: colorScheme.primary.withAlpha(alpha),
-            ),
-            padding: EdgeInsets.all(16.0),
-            child: Row(
-              mainAxisAlignment: MainAxisAlignment.spaceBetween,
-              children: [
-                AspectRatio(
-                  aspectRatio: 1.0,
-                  child: Container(
-                    alignment: Alignment.center,
-                    decoration: BoxDecoration(
-                      borderRadius: BorderRadius.circular(12),
-                      color: colorScheme.primary,
+              width: double.infinity,
+              height: Get.width / 2 / 1.618,
+              decoration: BoxDecoration(
+                borderRadius: BorderRadius.circular(20),
+                color: colorScheme.primary.withAlpha(alpha),
+              ),
+              padding: EdgeInsets.all(16.0),
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                children: [
+                  AspectRatio(
+                    aspectRatio: 1.0,
+                    child: Container(
+                      alignment: Alignment.center,
+                      decoration: BoxDecoration(
+                        borderRadius: BorderRadius.circular(12),
+                        color: colorScheme.primary,
+                      ),
+                      child: Text(
+                        'A',
+                        style: Theme.of(context)
+                            .textTheme
+                            .displayLarge!
+                            .copyWith(color: colorScheme.onPrimary),
+                      ),
                     ),
+                  ),
+                  SizedBox(width: 16),
+                  Container(
+                    alignment: Alignment.center,
                     child: Text(
-                      'A',
+                      '#${alpha.toRadixString(16).padLeft(2, '0').toUpperCase()}',
                       style: Theme.of(context)
                           .textTheme
-                          .displayLarge!
+                          .headlineLarge!
                           .copyWith(color: colorScheme.onPrimary),
                     ),
                   ),
-                ),
-                SizedBox(width: 16),
-                Container(
-                  alignment: Alignment.center,
-                  child: Text(
-                    '#${alpha.toRadixString(16).padLeft(2, '0').toUpperCase()}',
-                    style: Theme.of(context)
-                        .textTheme
-                        .headlineLarge!
-                        .copyWith(color: colorScheme.onPrimary),
-                  ),
-                ),
-              ],
+                ],
+              ),
             ),
           ),
-          ),
-          
         ],
       ),
     );

--- a/lib/src/debug/theme/sample_color_alpha.dart
+++ b/lib/src/debug/theme/sample_color_alpha.dart
@@ -6,9 +6,12 @@ import 'chessboard.dart';
 class SampleColorAlpha extends StatelessWidget {
   final int alpha;
 
+  final ValueChanged<Color>? onChanged;
+
   const SampleColorAlpha({
     super.key,
     required this.alpha,
+    this.onChanged,
   });
 
   @override
@@ -21,8 +24,17 @@ class SampleColorAlpha extends StatelessWidget {
       child: Stack(
         children: [
           ChessboardBackground(
-              size: Size.new(Get.width - 2 * 16.0, Get.width / 2 / 1.618)),
-          Container(
+              size: Size.new(Get.width - 2 * 8.0, Get.width / 2 / 1.618)),
+          GestureDetector(
+            onHorizontalDragEnd: (details) {
+                    if (details.primaryVelocity == null) return;
+                    if (details.primaryVelocity!.value < 0.0) {
+                      this.onChanged?.call((this.alpha + 256 - 1) % 256);
+                    } else if (details.primaryVelocity!.value > 0.0) {
+                      this.onChanged?.call((this.alpha + 1) % 256);
+                    }
+                  },
+            child: Container(
             width: double.infinity,
             height: Get.width / 2 / 1.618,
             decoration: BoxDecoration(
@@ -64,6 +76,8 @@ class SampleColorAlpha extends StatelessWidget {
               ],
             ),
           ),
+          ),
+          
         ],
       ),
     );

--- a/lib/src/debug/theme/sample_color_alpha.dart
+++ b/lib/src/debug/theme/sample_color_alpha.dart
@@ -20,13 +20,13 @@ class SampleColorAlpha extends StatelessWidget {
       borderRadius: BorderRadius.circular(20),
       child: Stack(
         children: [
-          ChessboardBackground(squareSize: Get.width / 2 / 1.618),
+          ChessboardBackground(size: Size.new(Get.width-2*16.0, Get.width / 2 / 1.618)),
           Container(
             width: double.infinity,
             height: Get.width / 2 / 1.618,
             decoration: BoxDecoration(
               borderRadius: BorderRadius.circular(20),
-              color: colorScheme.primary.withAlpha(alpha ~/ 2), // Применение прозрачности
+              color: colorScheme.primary.withAlpha(alpha),
             ),
             padding: EdgeInsets.all(16.0),
             child: Row(

--- a/lib/src/debug/theme/sample_color_alpha.dart
+++ b/lib/src/debug/theme/sample_color_alpha.dart
@@ -28,9 +28,9 @@ class SampleColorAlpha extends StatelessWidget {
           GestureDetector(
             onHorizontalDragEnd: (details) {
               if (details.primaryVelocity == null) return;
-              if (details.primaryVelocity!.value < 0.0) {
+              if (details.primaryVelocity! < 0.0) {
                 this.onChanged?.call((this.alpha + 256 - 1) % 256);
-              } else if (details.primaryVelocity!.value > 0.0) {
+              } else if (details.primaryVelocity! > 0.0) {
                 this.onChanged?.call((this.alpha + 1) % 256);
               }
             },

--- a/lib/src/debug/theme/sample_color_alpha.dart
+++ b/lib/src/debug/theme/sample_color_alpha.dart
@@ -20,7 +20,8 @@ class SampleColorAlpha extends StatelessWidget {
       borderRadius: BorderRadius.circular(20),
       child: Stack(
         children: [
-          ChessboardBackground(size: Size.new(Get.width-2*16.0, Get.width / 2 / 1.618)),
+          ChessboardBackground(
+              size: Size.new(Get.width - 2 * 16.0, Get.width / 2 / 1.618)),
           Container(
             width: double.infinity,
             height: Get.width / 2 / 1.618,
@@ -68,4 +69,3 @@ class SampleColorAlpha extends StatelessWidget {
     );
   }
 }
-

--- a/lib/src/debug/theme/sample_color_value.dart
+++ b/lib/src/debug/theme/sample_color_value.dart
@@ -16,7 +16,7 @@ class SampleColorValue extends StatelessWidget {
   Widget build(BuildContext context) {
     final colorScheme = Theme.of(context).colorScheme;
 
-final containerHeight = Get.width / 2 / 1.618;
+    final containerHeight = Get.width / 2 / 1.618;
     final containerColor =
         Color.fromARGB(value.alpha, value.red, value.green, value.blue);
 
@@ -25,7 +25,8 @@ final containerHeight = Get.width / 2 / 1.618;
       borderRadius: BorderRadius.circular(20),
       child: Stack(
         children: [
-          ChessboardBackground(size: Size.new(Get.width-2*16.0, Get.width / 2 / 1.618)),
+          ChessboardBackground(
+              size: Size.new(Get.width - 2 * 16.0, Get.width / 2 / 1.618)),
           Container(
             width: double.infinity,
             height: containerHeight,
@@ -60,7 +61,7 @@ final containerHeight = Get.width / 2 / 1.618;
                   child: Text(
                     '#${value.value.toRadixString(16).padLeft(2, '0').toUpperCase()}',
                     style: Theme.of(context).textTheme.headlineLarge!.copyWith(
-                    color: ColorUtils.contrastThemeColor(containerColor)),
+                        color: ColorUtils.contrastThemeColor(containerColor)),
                   ),
                 ),
               ],
@@ -71,4 +72,3 @@ final containerHeight = Get.width / 2 / 1.618;
     );
   }
 }
-

--- a/lib/src/debug/theme/sample_color_value.dart
+++ b/lib/src/debug/theme/sample_color_value.dart
@@ -25,7 +25,7 @@ final containerHeight = Get.width / 2 / 1.618;
       borderRadius: BorderRadius.circular(20),
       child: Stack(
         children: [
-          ChessboardBackground(squareSize: Get.width / 2 / 1.618),
+          ChessboardBackground(size: Size.new(Get.width-2*16.0, Get.width / 2 / 1.618)),
           Container(
             width: double.infinity,
             height: containerHeight,


### PR DESCRIPTION
## Summary by Sourcery

Enable interactive and reactive color adjustments in the debug theme by adding swipe-driven alpha control and using a ValueNotifier for live updates, while refactoring the chessboard background sizing and rounding.

New Features:
- Add onChanged callback and horizontal drag gesture to SampleColorAlpha for adjusting opacity by swiping
- Wrap all SampleColor widgets in ColorPage with a ValueNotifier and ValueListenableBuilder to propagate live color updates

Enhancements:
- Rename squareSize parameter to size in ChessboardBackground, wrap it in a rounded ClipRRect, and unify sizing calculations
- Refine layout, spacing, and text styling in SampleColorAlpha and SampleColorValue, including consistent hex code display