### PR TITLE
Update home_controller.dart

### DIFF
--- a/lib/src/debug/theme/color_page.dart
+++ b/lib/src/debug/theme/color_page.dart
@@ -31,7 +31,8 @@ class ColorPage extends StatelessWidget {
                 return SampleColorAlpha(
                   alpha: value.alpha,
                   onChanged: (newValue) {
-                    colorNotifier.value = colorNotifier.value.withAlpha(newValue);
+                    colorNotifier.value =
+                        colorNotifier.value.withAlpha(newValue);
                   },
                 ); // SampleColorAlpha
               },

--- a/lib/src/home/home_controller.dart
+++ b/lib/src/home/home_controller.dart
@@ -85,7 +85,8 @@ class HomeController extends GetxController {
 
 int fromJson(Map<String, dynamic> value) {
     int views = 0;
-    if (value) {
+    if (value['items'] != null) {
+      final items = value['items'];
     }
 }
 

--- a/lib/src/home/home_controller.dart
+++ b/lib/src/home/home_controller.dart
@@ -86,8 +86,12 @@ class HomeController extends GetxController {
 int fromJson(Map<String, dynamic> value) {
     int views = 0;
     if (value['items'] != null) {
-      final items = value['items'];
+      final items = value['items'] as List<dynamic>;
+      items.forEach((item) {
+    views += item['views'] ?? 0;
+});
     }
+return views;
 }
 
   void copyToClipboard() {

--- a/lib/src/home/home_controller.dart
+++ b/lib/src/home/home_controller.dart
@@ -110,22 +110,6 @@ return views;
         .where((a) => (a.wiki?.title?.length ?? 0) > 0)
         .toList();
     if (zeroes.length > 0) {
-      final piLink =
-          'https://en.wikipedia.org/w/index.php?title=${zeroes[0].wiki?.title}&action=info';
-      final text = await fetchString(piLink);
-      final document = parse(text);
-      final rows = document.querySelectorAll('div.mw-pvi-month');
-      if (rows.length > 0) {
-        int val = int.tryParse(rows[0].text.replaceAll(RegExp(r','), '')) ?? 0;
-        zeroes[0].wiki!.mviMonth = val;
-        zeroes[0].wiki!.lastUpdate = DateTime.now();
-      }
-      final imgs = document
-          .querySelectorAll('tr#mw-pageimages-info-label > td > a > img');
-      if (imgs.length > 0) {
-        String? imgLink = 'https:' + (imgs[0].attributes['src'] ?? '');
-        zeroes[0].wiki!.image = imgLink;
-      }
 
       if (zeroes[0].wiki != null && zeroes[0].wiki!.title != null) {
         final thisYear = await getWikipediaPageViews(zeroes[0].wiki!.title!);

--- a/lib/src/home/home_controller.dart
+++ b/lib/src/home/home_controller.dart
@@ -88,7 +88,7 @@ int fromJson(Map<String, dynamic> value) {
     if (value['items'] != null) {
       final items = value['items'] as List<dynamic>;
       items.forEach((item) {
-    views += item['views'] ?? 0;
+    views += item['views'] as int ?? 0;
 });
     }
 return views;

--- a/lib/src/home/home_controller.dart
+++ b/lib/src/home/home_controller.dart
@@ -72,8 +72,10 @@ class HomeController extends GetxController {
   }
 
   Future<Map<String, dynamic>> getWikipediaPageViews(String title) async {
+   final yesterday= DateTime.now().subtract(const Duration(days: 1));
+   final toDay DateFormat('yyyy-MM-dd').format(yesterday);
   final result = await fetchMap(
-        'https://wikimedia.org/api/rest_v1/metrics/pageviews/per-article/en.wikipedia.org/all-access/all-agents/$title/daily/20250101/20250914');
+        'https://wikimedia.org/api/rest_v1/metrics/pageviews/per-article/en.wikipedia.org/all-access/all-agents/$title/daily/20250101/$toDay');
  
 }
 

--- a/lib/src/home/home_controller.dart
+++ b/lib/src/home/home_controller.dart
@@ -72,27 +72,27 @@ class HomeController extends GetxController {
   }
 
   Future<int> getWikipediaPageViews(String title) async {
-   final yesterday= DateTime.now().subtract(const Duration(days: 1));
-   final toDay = DateFormat('yyyyMMdd').format(yesterday);
-  final result = await fetchMap(
+    final yesterday = DateTime.now().subtract(const Duration(days: 1));
+    final toDay = DateFormat('yyyyMMdd').format(yesterday);
+    final result = await fetchMap(
         'https://wikimedia.org/api/rest_v1/metrics/pageviews/per-article/en.wikipedia.org/all-access/all-agents/$title/daily/20250101/$toDay');
- return switch (result) {
+    return switch (result) {
       ErrorResult _ => -1,
       ValueResult v => fromJson(v.value),
       _ => 0,
     };
-}
+  }
 
-int fromJson(Map<String, dynamic> value) {
+  int fromJson(Map<String, dynamic> value) {
     int views = 0;
     if (value['items'] != null) {
       final items = value['items'] as List<dynamic>;
       items.forEach((item) {
-    views += item['views'] as int;
-});
+        views += item['views'] as int;
+      });
     }
-return views;
-}
+    return views;
+  }
 
   void copyToClipboard() {
     final encoder = JsonEncoder.withIndent('   ');
@@ -110,7 +110,6 @@ return views;
         .where((a) => (a.wiki?.title?.length ?? 0) > 0)
         .toList();
     if (zeroes.length > 0) {
-
       if (zeroes[0].wiki != null && zeroes[0].wiki!.title != null) {
         final thisYear = await getWikipediaPageViews(zeroes[0].wiki!.title!);
         zeroes[0].wiki!.mviMonth = thisYear;

--- a/lib/src/home/home_controller.dart
+++ b/lib/src/home/home_controller.dart
@@ -6,7 +6,7 @@ import 'package:async/async.dart';
 import 'package:dio/dio.dart' as dio;
 import 'package:flutter/services.dart';
 import 'package:get/get.dart';
-import 'package:html/parser.dart';
+import 'package:intl/intl.dart';
 import 'package:nanoid2/nanoid2.dart';
 
 import 'entities/anime.dart';
@@ -77,7 +77,7 @@ class HomeController extends GetxController {
   final result = await fetchMap(
         'https://wikimedia.org/api/rest_v1/metrics/pageviews/per-article/en.wikipedia.org/all-access/all-agents/$title/daily/20250101/$toDay');
  return switch (result) {
-      ErrorResult e => -1,
+      ErrorResult _ => -1,
       ValueResult v => fromJson(v.value),
       _ => 0,
     };

--- a/lib/src/home/home_controller.dart
+++ b/lib/src/home/home_controller.dart
@@ -83,6 +83,12 @@ class HomeController extends GetxController {
     };
 }
 
+int fromJson(Map<String, dynamic> value) {
+    int views = 0;
+    if (value) {
+    }
+}
+
   void copyToClipboard() {
     final encoder = JsonEncoder.withIndent('   ');
     Clipboard.setData(ClipboardData(text: encoder.convert(animeList)));

--- a/lib/src/home/home_controller.dart
+++ b/lib/src/home/home_controller.dart
@@ -73,7 +73,7 @@ class HomeController extends GetxController {
 
   Future<int> getWikipediaPageViews(String title) async {
    final yesterday= DateTime.now().subtract(const Duration(days: 1));
-   final toDay DateFormat('yyyy-MM-dd').format(yesterday);
+   final toDay = DateFormat('yyyyMMdd').format(yesterday);
   final result = await fetchMap(
         'https://wikimedia.org/api/rest_v1/metrics/pageviews/per-article/en.wikipedia.org/all-access/all-agents/$title/daily/20250101/$toDay');
  return switch (result) {

--- a/lib/src/home/home_controller.dart
+++ b/lib/src/home/home_controller.dart
@@ -88,7 +88,7 @@ int fromJson(Map<String, dynamic> value) {
     if (value['items'] != null) {
       final items = value['items'] as List<dynamic>;
       items.forEach((item) {
-    views += item['views'] as int ?? 0;
+    views += item['views'] as int;
 });
     }
 return views;

--- a/lib/src/home/home_controller.dart
+++ b/lib/src/home/home_controller.dart
@@ -71,6 +71,12 @@ class HomeController extends GetxController {
     };
   }
 
+  Future<Map<String, dynamic>> getWikipediaPageViews(String title) async {
+  final result = await fetchMap(
+        'https://wikimedia.org/api/rest_v1/metrics/pageviews/per-article/en.wikipedia.org/all-access/all-agents/$title/daily/20250101/20250914');
+ 
+}
+
   void copyToClipboard() {
     final encoder = JsonEncoder.withIndent('   ');
     Clipboard.setData(ClipboardData(text: encoder.convert(animeList)));

--- a/lib/src/home/home_controller.dart
+++ b/lib/src/home/home_controller.dart
@@ -119,6 +119,7 @@ class HomeController extends GetxController {
       if (zeroes[0].wiki != null && zeroes[0].wiki!.title != null) {
         final sum = await readSummary(zeroes[0].wiki!.title!);
         zeroes[0].wiki!.description = sum.extract;
+        zeroes[0].wiki!.image = sum.originalImage.source;
       }
 
       animeList.sort(

--- a/lib/src/home/home_controller.dart
+++ b/lib/src/home/home_controller.dart
@@ -126,10 +126,18 @@ return views;
         String? imgLink = 'https:' + (imgs[0].attributes['src'] ?? '');
         zeroes[0].wiki!.image = imgLink;
       }
+
+      if (zeroes[0].wiki != null && zeroes[0].wiki!.title != null) {
+        final thisYear = await getWikipediaPageViews(zeroes[0].wiki!.title!);
+        zeroes[0].wiki!.mviMonth = thisYear;
+        zeroes[0].wiki!.lastUpdate = DateTime.now();
+      }
+
       if (zeroes[0].wiki != null && zeroes[0].wiki!.title != null) {
         final sum = await readSummary(zeroes[0].wiki!.title!);
         zeroes[0].wiki!.description = sum.extract;
       }
+
       animeList.sort(
           (a, b) => (b.wiki?.mviMonth ?? 0).compareTo(a.wiki?.mviMonth ?? 0));
       animeList.refresh();

--- a/lib/src/home/home_controller.dart
+++ b/lib/src/home/home_controller.dart
@@ -71,12 +71,16 @@ class HomeController extends GetxController {
     };
   }
 
-  Future<Map<String, dynamic>> getWikipediaPageViews(String title) async {
+  Future<int> getWikipediaPageViews(String title) async {
    final yesterday= DateTime.now().subtract(const Duration(days: 1));
    final toDay DateFormat('yyyy-MM-dd').format(yesterday);
   final result = await fetchMap(
         'https://wikimedia.org/api/rest_v1/metrics/pageviews/per-article/en.wikipedia.org/all-access/all-agents/$title/daily/20250101/$toDay');
- 
+ return switch (result) {
+      ErrorResult e => -1,
+      ValueResult v => fromJson(v.value),
+      _ => 0,
+    };
 }
 
   void copyToClipboard() {


### PR DESCRIPTION
## Summary by Sourcery

Switch the home controller to use the Wikimedia REST Pageviews API for obtaining page view metrics, implement JSON parsing for view aggregation, and eliminate deprecated scraping of page information and images.

New Features:
- Add getWikipediaPageViews method to fetch and aggregate daily page views via the Wikimedia REST API.

Enhancements:
- Replace manual HTML scraping of page view counts with API-based data retrieval.
- Remove HTML scraping of page images, simplifying the controller logic.